### PR TITLE
RF-11339 Fix for selection hangs in extendedDataTable when there are more than one table in the view

### DIFF
--- a/iteration/ui/src/main/resources/META-INF/resources/org.richfaces/extendedDataTable.js
+++ b/iteration/ui/src/main/resources/META-INF/resources/org.richfaces/extendedDataTable.js
@@ -140,7 +140,6 @@
 
             name: "ExtendedDataTable",
 
-            ranges: new richfaces.utils.Ranges(),
             resizeData: {},
             idOfReorderingColumn: "",
             newWidths: {},
@@ -148,6 +147,7 @@
 
             init: function (id, rowCount, ajaxFunction, options) {
                 $super.constructor.call(this, id);
+                this.ranges = new richfaces.utils.Ranges();
                 this.rowCount = rowCount;
                 this.ajaxFunction = ajaxFunction;
                 this.options = options || {};


### PR DESCRIPTION
Problem with selection in extendedDataTables when there are two tables in one form. 
Some of the selections are not removed when a new row is selected.

Signed-off-by: Morten Ludvigsen mortenlud@gmail.com
