### PR TITLE
https://issues.jboss.org/browse/RF-10961

### DIFF
--- a/output/ui/src/main/java/org/richfaces/component/AbstractTabPanel.java
+++ b/output/ui/src/main/java/org/richfaces/component/AbstractTabPanel.java
@@ -51,11 +51,11 @@ public abstract class AbstractTabPanel extends AbstractTogglePanel {
     @Attribute(generate = false)
     public String getActiveItem() {
         String res = super.getActiveItem();
-        if (res == null) {
+        if ((res == null)||(res.equals(""))) {
             res = getFirstItem().getName();
         } else {
             AbstractTogglePanelTitledItem item = (AbstractTogglePanelTitledItem) super.getItemByIndex(super.getChildIndex(res));
-            if (item.isDisabled()) {
+            if ((item == null)||(item.isDisabled())) {
                 res = getFirstItem().getName();
             }
         }


### PR DESCRIPTION
https://issues.jboss.org/browse/RF-10961 fixed.

activeITem=""
and activeItem="wrongName" now both results in opening of the default tab without exceptions.
