### PR TITLE
https://issues.jboss.org/browse/RF-10848

### DIFF
--- a/misc/ui/src/main/java/org/richfaces/component/AbstractHotKey.java
+++ b/misc/ui/src/main/java/org/richfaces/component/AbstractHotKey.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc. and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.richfaces.component;
+
+import javax.faces.component.UIComponentBase;
+
+import org.richfaces.cdk.annotations.Attribute;
+import org.richfaces.cdk.annotations.JsfComponent;
+import org.richfaces.cdk.annotations.JsfRenderer;
+import org.richfaces.cdk.annotations.Tag;
+import org.richfaces.cdk.annotations.TagType;
+
+/**
+ * @author ilya_shaikovsky
+ *
+ */
+@JsfComponent(type = AbstractHotKey.COMPONENT_TYPE, family = AbstractHotKey.COMPONENT_FAMILY, renderer = @JsfRenderer(type = "org.richfaces.HotKeyRenderer"), tag = @Tag(type = TagType.Facelets))
+public abstract class AbstractHotKey extends UIComponentBase {
+    public static final String COMPONENT_TYPE = "org.richfaces.HotKey";
+    public static final String COMPONENT_FAMILY = "org.richfaces.HotKey";
+
+    @Attribute(required = true)
+    public abstract String getKey();
+
+    @Attribute(required = true)
+    public abstract String getHandler();
+
+    @Attribute
+    public abstract String getType();
+
+    @Attribute(defaultValue = "true")
+    public abstract boolean isDisableInInput();
+
+    @Attribute
+    public abstract String getSelector();
+}

--- a/misc/ui/src/main/java/org/richfaces/renderkit/HotKeyRendererBase.java
+++ b/misc/ui/src/main/java/org/richfaces/renderkit/HotKeyRendererBase.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc. and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.richfaces.renderkit;
+
+import javax.faces.application.ResourceDependencies;
+import javax.faces.application.ResourceDependency;
+import javax.faces.render.Renderer;
+
+/**
+ * @author ilya_shaikovsky
+ *
+ */
+@ResourceDependencies({ @ResourceDependency(name = "jquery.js"),
+        @ResourceDependency(library = "org.richfaces", name = "jquery.hotkeys.js"),
+        @ResourceDependency(library = "org.richfaces", name = "hotkey.js")})
+public abstract class HotKeyRendererBase extends Renderer {
+}

--- a/misc/ui/src/main/resources/META-INF/resources/org.richfaces/hotkey.js
+++ b/misc/ui/src/main/resources/META-INF/resources/org.richfaces/hotkey.js
@@ -1,0 +1,34 @@
+if (!window.RichFaces) {
+    window.RichFaces = {};
+}
+(function ($, rf) {
+
+    rf.ui = rf.ui || {};
+    var defaultOptions = {
+    		type : 'keyup',
+        	disableInInput : true
+    };
+    rf.ui.HotKey = function(componentId, options) {
+        this.options = $.extend(this.options, defaultOptions, options);
+        this.type = this.options.type;
+        this.handler = this.options.handler;
+        this.key = this.options.key;
+        this.disableInInput = this.options.disableInInput;
+        this.selector = this.options.selector;
+        //TODO: improve to support just id as for other components.
+        if (!this.selector){
+        	jQuery(document).bind(this.type, this.options, rf.ui.HotKey.resolveHandler(this.handler));
+        }else{
+        	jQuery(this.selector).live(this.type, this.options, rf.ui.HotKey.resolveHandler(this.handler));
+        }
+    };
+    rf.ui.HotKey.resolveHandler = function(handlerBody) {
+    	if (handlerBody) {
+    		if (typeof handlerBody == "function") {
+    			return handlerBody;
+    		} else {
+    			return new Function("event", handlerBody);
+    		}
+    	}
+    };
+})(jQuery, RichFaces);

--- a/misc/ui/src/main/resources/META-INF/resources/org.richfaces/jquery.hotkeys.js
+++ b/misc/ui/src/main/resources/META-INF/resources/org.richfaces/jquery.hotkeys.js
@@ -1,0 +1,97 @@
+/*
+ * jQuery Hotkeys Plugin
+ * Copyright 2010, John Resig
+ * Dual licensed under the MIT or GPL Version 2 licenses.
+ *
+ * Based upon the plugin by Tzury Bar Yochay:
+ * http://github.com/tzuryby/hotkeys
+ *
+ * Original idea by:
+ * Binny V A, http://www.openjs.com/scripts/events/keyboard_shortcuts/
+*/
+
+(function(jQuery){
+
+	jQuery.hotkeys = {
+		version: "0.8",
+
+		specialKeys: {
+			8: "backspace", 9: "tab", 13: "return", 16: "shift", 17: "ctrl", 18: "alt", 19: "pause",
+			20: "capslock", 27: "esc", 32: "space", 33: "pageup", 34: "pagedown", 35: "end", 36: "home",
+			37: "left", 38: "up", 39: "right", 40: "down", 45: "insert", 46: "del", 
+			96: "0", 97: "1", 98: "2", 99: "3", 100: "4", 101: "5", 102: "6", 103: "7",
+			104: "8", 105: "9", 106: "*", 107: "+", 109: "-", 110: ".", 111 : "/", 
+			112: "f1", 113: "f2", 114: "f3", 115: "f4", 116: "f5", 117: "f6", 118: "f7", 119: "f8", 
+			120: "f9", 121: "f10", 122: "f11", 123: "f12", 144: "numlock", 145: "scroll", 191: "/", 224: "meta"
+		},
+
+		shiftNums: {
+			"`": "~", "1": "!", "2": "@", "3": "#", "4": "$", "5": "%", "6": "^", "7": "&", 
+			"8": "*", "9": "(", "0": ")", "-": "_", "=": "+", ";": ": ", "'": "\"", ",": "<", 
+			".": ">",  "/": "?",  "\\": "|"
+		}
+	};
+
+	function keyHandler( handleObj ) {
+		if ( typeof handleObj.data.key !== "string" ) {
+			return;
+		}
+		var origHandler = handleObj.handler,
+			keys = handleObj.data.key.toLowerCase().split(" ");
+
+		handleObj.handler = function( event ) {
+			// Don't fire in text-accepting inputs that we didn't directly bind to
+			if ((this !== event.target && (/textarea|select/i.test( event.target.nodeName ) ||
+				 event.target.type === "text"))&&(handleObj.data.disableInInput)) {
+				return;
+			}
+
+			// Keypress represents characters, not special keys
+			var special = event.type !== "keypress" && jQuery.hotkeys.specialKeys[ event.which ],
+				character = String.fromCharCode( event.which ).toLowerCase(),
+				key, modif = "", possible = {};
+
+			// check combinations (alt|ctrl|shift+anything)
+			if ( event.altKey && special !== "alt" ) {
+				modif += "alt+";
+			}
+
+			if ( event.ctrlKey && special !== "ctrl" ) {
+				modif += "ctrl+";
+			}
+
+			// TODO: Need to make sure this works consistently across platforms
+			if ( event.metaKey && !event.ctrlKey && special !== "meta" ) {
+				modif += "meta+";
+			}
+
+			if ( event.shiftKey && special !== "shift" ) {
+				modif += "shift+";
+			}
+
+			if ( special ) {
+				possible[ modif + special ] = true;
+
+			} else {
+				possible[ modif + character ] = true;
+				possible[ modif + jQuery.hotkeys.shiftNums[ character ] ] = true;
+
+				// "$" can be triggered as "Shift+4" or "Shift+$" or just "$"
+				if ( modif === "shift+" ) {
+					possible[ jQuery.hotkeys.shiftNums[ character ] ] = true;
+				}
+			}
+
+			for ( var i = 0, l = keys.length; i < l; i++ ) {
+				if ( possible[ keys[i] ] ) {
+					return origHandler.apply( this, arguments );
+				}
+			}
+		};
+	}
+
+	jQuery.each([ "keydown", "keyup", "keypress" ], function() {
+		jQuery.event.special[ this ] = { add: keyHandler };
+	});
+
+})( jQuery );

--- a/misc/ui/src/main/templates/hotKey.template.xml
+++ b/misc/ui/src/main/templates/hotKey.template.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<cdk:root xmlns="http://jboss.org/schema/richfaces/cdk/xhtml-el" xmlns:cdk="http://jboss.org/schema/richfaces/cdk/core"
+    xmlns:c="http://jboss.org/schema/richfaces/cdk/jstl/core" xmlns:cc="http://jboss.org/schema/richfaces/cdk/jsf/composite"
+    xmlns:javaee="http://java.sun.com/xml/ns/javaee">
+
+    <cc:interface>
+        <cdk:class>org.richfaces.renderkit.html.HotKeyRenderer</cdk:class>
+        <cdk:superclass>org.richfaces.renderkit.HotKeyRendererBase</cdk:superclass>
+        <cdk:component-family>org.richfaces.HotKey</cdk:component-family>
+        <cdk:renderer-type>org.richfaces.HotKeyRenderer</cdk:renderer-type>
+    </cc:interface>
+
+    <cc:implementation>
+        <span id="#{clientId}" style="display: none;">
+            <script type="text/javascript">
+                <cdk:scriptObject name="options">
+                    <cdk:scriptOption attributes="key handler selector disableInInput" />
+                    <cdk:scriptOption name="type" value="#{component.attributes['type']}" defaultValue='"keypress"'/>
+                </cdk:scriptObject>
+				new RichFaces.ui.HotKey("#{clientId}",  #{toScriptArgs(options)});
+            </script>
+        </span>
+    </cc:implementation>
+
+</cdk:root>


### PR DESCRIPTION
used https://github.com/jeresig/jquery.hotkeys as a base
added selector instead of binding to just document
added disableInInput which was exist in 3.3

will also rise pull request for demo used during that migration. 
