### PR TITLE
RF-12154: richValidator: @disabled=true throws exception

### DIFF
--- a/validator/ui/src/main/java/org/richfaces/renderkit/html/ClientValidatorRenderer.java
+++ b/validator/ui/src/main/java/org/richfaces/renderkit/html/ClientValidatorRenderer.java
@@ -57,7 +57,11 @@ public class ClientValidatorRenderer extends ClientBehaviorRenderer {
         }
         if (behavior instanceof ClientValidatorBehavior) {
             ClientValidatorBehavior clientValidator = (ClientValidatorBehavior) behavior;
-            return buildAndStoreValidatorScript(behaviorContext, clientValidator);
+            if (clientValidator.isDisabled()){
+            	return null;
+            } else {
+            	return buildAndStoreValidatorScript(behaviorContext, clientValidator);
+            }
         } else {
             throw new FacesException(
                 "ClientBehavior for ClientValidatorRenderer does not implement ClientValidatorBehavior interface");

--- a/validator/ui/src/main/java/org/richfaces/renderkit/html/ClientValidatorRenderer.java
+++ b/validator/ui/src/main/java/org/richfaces/renderkit/html/ClientValidatorRenderer.java
@@ -58,9 +58,9 @@ public class ClientValidatorRenderer extends ClientBehaviorRenderer {
         if (behavior instanceof ClientValidatorBehavior) {
             ClientValidatorBehavior clientValidator = (ClientValidatorBehavior) behavior;
             if (clientValidator.isDisabled()){
-            	return null;
+                return null;
             } else {
-            	return buildAndStoreValidatorScript(behaviorContext, clientValidator);
+                return buildAndStoreValidatorScript(behaviorContext, clientValidator);
             }
         } else {
             throw new FacesException(


### PR DESCRIPTION
Hello I'm Luca Nardelli and this is my first contribution.

I fixed the issue by following the jsf specification that states ClientBehaviorRenderer implementation may return null if the associated ClientBehavior is disabled.
