### PR TITLE
Tooltip: RF-10839, RF-12198, RF-12199, RF-11370

### DIFF
--- a/output/ui/src/main/java/org/richfaces/renderkit/html/TooltipRenderer.java
+++ b/output/ui/src/main/java/org/richfaces/renderkit/html/TooltipRenderer.java
@@ -41,10 +41,12 @@ import javax.faces.context.ResponseWriter;
 
 import org.ajax4jsf.javascript.JSObject;
 import org.richfaces.TooltipMode;
+import org.richfaces.application.ServiceTracker;
 import org.richfaces.cdk.annotations.JsfRenderer;
 import org.richfaces.component.AbstractTooltip;
 import org.richfaces.component.Positioning;
 import org.richfaces.context.ExtendedPartialViewContext;
+import org.richfaces.javascript.JavaScriptService;
 import org.richfaces.renderkit.HtmlConstants;
 import org.richfaces.renderkit.MetaComponentRenderer;
 import org.richfaces.renderkit.RenderKitUtils;
@@ -236,6 +238,16 @@ public class TooltipRenderer extends DivPanelRenderer implements MetaComponentRe
         writeJavaScript(writer, context, component);
 
         writer.endElement(getMarkupElement((AbstractTooltip) component));
+    }
+
+    protected void writeJavaScript(ResponseWriter writer, FacesContext context, UIComponent component) throws IOException {
+        Object script = getScriptObject(context, component);
+        if (script == null) {
+            return;
+        }
+
+        JavaScriptService javaScriptService = ServiceTracker.getService(JavaScriptService.class);
+        javaScriptService.addScript(context, script);
     }
 
     public void encodeMetaComponent(FacesContext context, UIComponent component, String metaComponentId) throws IOException {

--- a/output/ui/src/main/java/org/richfaces/renderkit/html/TooltipRenderer.java
+++ b/output/ui/src/main/java/org/richfaces/renderkit/html/TooltipRenderer.java
@@ -31,7 +31,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.el.ValueExpression;
 import javax.faces.application.ResourceDependencies;
 import javax.faces.application.ResourceDependency;
 import javax.faces.component.UIComponent;
@@ -200,8 +199,12 @@ public class TooltipRenderer extends DivPanelRenderer implements MetaComponentRe
         RenderKitUtils.addToScriptHash(options, "showDelay", tooltip.getShowDelay(), 0);
         RenderKitUtils.addToScriptHash(options, "showEvent", tooltip.getShowEvent(), "mouseenter");
         RenderKitUtils.addToScriptHash(options, "followMouse", tooltip.isFollowMouse(), true);
-        RenderKitUtils.addToScriptHash(options, "target", RENDERER_UTILS.findComponentFor(component, tooltip.getTarget())
-            .getClientId(context));
+        String target = tooltip.getTarget();
+        UIComponent targetComponent = RENDERER_UTILS.findComponentFor(component, target);
+        if (targetComponent != null) {
+            target = targetComponent.getClientId();
+        }
+        RenderKitUtils.addToScriptHash(options, "target", target);
 
         addEventOption(context, tooltip, options, HIDE);
         addEventOption(context, tooltip, options, SHOW);

--- a/output/ui/src/test/resources/org/richfaces/renderkit/html/tooltip.xmlunit.xml
+++ b/output/ui/src/test/resources/org/richfaces/renderkit/html/tooltip.xmlunit.xml
@@ -4,7 +4,4 @@
             <span id="f:tooltip:content" class="rf-tt-cnt"></span>
         </span>
     </span>
-    <script type="text/javascript">
-        // Text
-    </script>
 </span>


### PR DESCRIPTION
RF-12199: rich:tooltip does not work inside h:graphicImage
RF-12198: rich:tooltip does not work inside a4j:commandButton
RF-10839: tooltip: attachment using target not works if tooltip defined before the component to which it attaches.
Proposed rich:tooltip migration to JavaScriptService.

RF-11370: Metamer: rich:toolTip: targetted example causes NPE for some IDs
Fixed NPE

RF-11343: tooltip: does not work attached to parent input
commented (should be resolved)
