### PR TITLE
RF-12372: inputNumberSlider not changing value if out of range

### DIFF
--- a/input/ui/src/main/resources/META-INF/resources/org.richfaces/inputNumberSlider.js
+++ b/input/ui/src/main/resources/META-INF/resources/org.richfaces/inputNumberSlider.js
@@ -117,12 +117,21 @@
 
             __setValue: function (value, event, skipOnchange) {
                 if (!isNaN(value)) {
+                    var changed = false; // RF-12372
+                    if (this.input.val() == "") {
+                        // value already changed from "" to 0, compare to
+                        // real value to track changes
+                        changed = true;
+                    }
+
                     if (value > this.maxValue) {
                         value = this.maxValue;
+                        changed = true;
                     } else if (value < this.minValue) {
                         value = this.minValue;
+                        changed = true;
                     }
-                    if (value != this.value) {
+                    if (value != this.value || changed) {
                         this.input.val(value);
                         var left = 100 * (value - this.minValue) / this.range;
                         this.handleContainer.css("padding-left", left + "%");


### PR DESCRIPTION
Fixed 2 issues described in the bug:
1) changes will not be recognized as such if value less than minValue or value greater than maxValue blur'ed
2) changing input to empty string will not be recognized as such, for sliders with minValue of 0 if blur'ed 2 times
