### PR TITLE
RF-12481: Fix autocomplete does not close the popup in destroy method. 

### DIFF
--- a/input/ui/src/main/resources/META-INF/resources/org.richfaces/Autocomplete.js
+++ b/input/ui/src/main/resources/META-INF/resources/org.richfaces/Autocomplete.js
@@ -472,6 +472,7 @@
              */
             destroy: function () {
                 //TODO: add all unbind
+                this.__hide(event);
                 this.items = null;
                 this.cache = null;
                 var itemsContainer = rf.getDomElement(this.id + ID.ITEMS);

--- a/input/ui/src/main/resources/META-INF/resources/org.richfaces/Autocomplete.js
+++ b/input/ui/src/main/resources/META-INF/resources/org.richfaces/Autocomplete.js
@@ -472,6 +472,7 @@
              */
             destroy: function () {
                 //TODO: add all unbind
+            	this.__hide(event);
                 this.items = null;
                 this.cache = null;
                 var itemsContainer = rf.getDomElement(this.id + ID.ITEMS);

--- a/input/ui/src/main/resources/META-INF/resources/org.richfaces/Autocomplete.js
+++ b/input/ui/src/main/resources/META-INF/resources/org.richfaces/Autocomplete.js
@@ -472,7 +472,7 @@
              */
             destroy: function () {
                 //TODO: add all unbind
-            	this.__hide(event);
+                this.__hide(event);
                 this.items = null;
                 this.cache = null;
                 var itemsContainer = rf.getDomElement(this.id + ID.ITEMS);


### PR DESCRIPTION
The Suggestion popup is left hanging on the page.
If an Autocomplete is rendered while the item list is shown, the destroy method is not closing the item list (popup box). The item list is left hanging on the page.
The only way to remove the items is to refresh the whole page.
