### PR TITLE
fix for RF-12387 

### DIFF
--- a/input/ui/src/main/resources/META-INF/resources/org.richfaces/inputNumberSlider.js
+++ b/input/ui/src/main/resources/META-INF/resources/org.richfaces/inputNumberSlider.js
@@ -125,9 +125,11 @@
 
                     if (value > this.maxValue) {
                         value = this.maxValue;
+                        this.input.val(value);
                         changed = true;
                     } else if (value < this.minValue) {
                         value = this.minValue;
+                        this.input.val(value);
                         changed = true;
                     }
                     if (value != this.value || changed) {


### PR DESCRIPTION
rich:inputNumberSlider minValue and maxValue being ignored after second request (the same fix as for rich:inputNumberSpinner)
