### PR TITLE
Fix invalid CSS in popupPanel.ecss

### DIFF
--- a/output/ui/src/main/resources/META-INF/resources/org.richfaces/popupPanel.ecss
+++ b/output/ui/src/main/resources/META-INF/resources/org.richfaces/popupPanel.ecss
@@ -8,7 +8,7 @@
     top: 0px;
     z-index: -300;
     opacity: 0.1;
-    filter: 'alpha(opacity=10)';
+    filter: alpha(opacity=10);
 }
 
 .rf-pp-shade {
@@ -19,13 +19,13 @@
     left: 0px;
     background-color: #D0D0D0;
     opacity: 0.5;
-    filter: 'alpha(opacity=50)';
+    filter: alpha(opacity=50);
 }
 
 .rf-pp-shdw {
     background-color: #000000;
     opacity: 0.1;
-    filter: 'alpha(opacity=10)';
+    filter: alpha(opacity=10);
     position: absolute;
     top: 6px;
     left: 6px;


### PR DESCRIPTION
The CSSParser seems to unquote all strings, even those without EL expressions. If you fix this, this CSS is invalid.
