### PR TITLE
RF-12673: Cleared UIDataTableBase extendedDataModel prior to component encoding

### DIFF
--- a/common/ui/src/main/java/org/richfaces/component/UIDataAdaptor.java
+++ b/common/ui/src/main/java/org/richfaces/component/UIDataAdaptor.java
@@ -466,6 +466,10 @@ public abstract class UIDataAdaptor extends UIComponentBase implements NamingCon
 
     protected abstract ExtendedDataModel<?> createExtendedDataModel();
 
+    public void clearExtendedDataModel() {
+        setExtendedDataModel(null);
+    }
+
     /**
      * @param extendedDataModel the extendedDataModel to set
      */

--- a/iteration/ui/src/main/java/org/richfaces/renderkit/AbstractTableRenderer.java
+++ b/iteration/ui/src/main/java/org/richfaces/renderkit/AbstractTableRenderer.java
@@ -190,6 +190,23 @@ public abstract class AbstractTableRenderer extends AbstractTableBaseRenderer im
         writer.endElement(HtmlConstants.TR_ELEMENT);
     }
 
+    /**
+     * Clear the extendedDataModel before the component encode begins.  This is to force the extendedDataModel to be
+     * re-initialized taking into account any model changes that were applied since the model was created in the
+     * RESTORE_VIEW phase.
+     *
+     * @param context
+     * @param component
+     * @throws IOException
+     */
+    @Override
+    protected void preEncodeBegin(FacesContext context, UIComponent component) throws IOException {
+        super.preEncodeBegin(context, component);
+        if (component instanceof UIDataTableBase) {
+            ((UIDataTableBase) component).clearExtendedDataModel();
+        }
+    }
+
     protected void doEncodeChildren(ResponseWriter writer, FacesContext context, UIComponent component) throws IOException {
         if (component instanceof UIDataTableBase) {
             encodeTableRows(writer, context, (UIDataTableBase) component, false);


### PR DESCRIPTION
The problem was introduced with the commit:
https://github.com/richfaces/components/commit/d65e614ef03adf87c0b6df2288689f0fd78d3a77

Since that commit, the ExtendedDataModel is instantiated in the RESTORE_VIEW phase, and is not re-instantiated again throughout the lifecycle. As such the ArrangeableModel filter method is not invoked after the filter input value is updated in the UPDATE_MODEL_VALUES phase.

This fix involves clearing the ExtendedDataModel at the beginning of the encode method, to force a re-evaluation of the ArrangeableModel.
