### PR TITLE
Fixed <rich:jQuery> default argument.

### DIFF
--- a/misc/ui/src/main/resources/META-INF/resources/org.richfaces/jquery.component.js
+++ b/misc/ui/src/main/resources/META-INF/resources/org.richfaces/jquery.component.js
@@ -37,9 +37,15 @@ if (!window.RichFaces) {
             var element;
             var options;
 
-            if (arguments.length == 1) {
-                //function(options) { ...query()... }
-                options = arguments[0];
+            if (arguments.length == 1) {             
+    	        if (!opts.selector) {
+		        	//if selector is not present take selector as default
+		         	element = arguments[0];
+	        	}else{
+		        	//if selector is allready presen from rich jQuery component take options as default.
+			        options = arguments[0];	
+	        	}		     
+		
             } else {
                 //function(element, options) { ...query()... }
                 element = arguments[0];


### PR DESCRIPTION
If you call a named jQuery function with this fix it will check if there already is an selector defined by the rich:jQuery tag. If it already exists he will default to "options" otherwise he will expect the selector to be the default argument.
