### PR TITLE
RF-13719 rich.fileUpload breaks form action in portal

### DIFF
--- a/input/ui/src/main/resources/META-INF/resources/org.richfaces/fileupload.js
+++ b/input/ui/src/main/resources/META-INF/resources/org.richfaces/fileupload.js
@@ -190,12 +190,13 @@
 
             __submit: function() {
                 var encodedURLInputs = this.form.children("input[name='javax.faces.encodedURL']");
-                var originalAction = encodedURLInputs.length > 0 ? encodedURLInputs.val() : this.form.attr("action");
+                var originalAction = this.form.attr("action");
+                var uploadAction = encodedURLInputs.length > 0 ? encodedURLInputs.val() : originalAction;
                 var originalEncoding = this.form.attr("encoding");
                 var originalEnctype = this.form.attr("enctype");
                 try {
-                    var delimiter = originalAction.indexOf("?") == -1 ? "?" : "&";
-                    this.form.attr("action", originalAction + delimiter + UID + "=" + this.loadableItem.uid);
+                    var delimiter = uploadAction.indexOf("?") == -1 ? "?" : "&";
+                    this.form.attr("action", uploadAction + delimiter + UID + "=" + this.loadableItem.uid);
                     this.form.attr("encoding", "multipart/form-data");
                     this.form.attr("enctype", "multipart/form-data");
                     richfaces.submitForm(this.form, {"org.richfaces.ajax.component": this.id}, this.id);


### PR DESCRIPTION
- Modify fileupload.js to retain the original form action, such that if a partial action is used to upload the file, the original non partial action can be set on the form on completion of the upload
